### PR TITLE
Added the ability to run any shortcut in the Shortcuts app on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,7 @@ Sending some other value but `shutdown` will do nothing.
 ### PREFIX + `/command/displaysleep`
 
 You can send string `displaysleep` to this topic. It will turn off display. Sending some other value will do nothing.
+
+### PREFIX + `/command/runshortcut`
+
+You can send the name of a shortcut to this topic. It will run this shortcut in the Shortcuts app.

--- a/mac2mqtt.go
+++ b/mac2mqtt.go
@@ -153,6 +153,10 @@ func commandShutdown() {
 
 }
 
+func commandRunShortcut(shortcut string) {
+	runCommand("shortcuts", "run", shortcut)
+}
+
 var messagePubHandler mqtt.MessageHandler = func(client mqtt.Client, msg mqtt.Message) {
 	log.Printf("Received message: %s from topic: %s\n", msg.Payload(), msg.Topic())
 }
@@ -252,6 +256,10 @@ func listen(client mqtt.Client, topic string) {
 				commandShutdown()
 			}
 
+		}
+
+		if msg.Topic() == getTopicPrefix()+"/command/runshortcut" {
+			commandRunShortcut(string(msg.Payload()))
 		}
 
 	})


### PR DESCRIPTION
TIL that there's a `shortcuts` CLI tool on Mac, and you can use this to run any shortcut in the Shortcuts app. This opens up a ton of possibilities!

For example, I added a "Turn on Do Not Disturb" shortcut:
 
<img width="1200" alt="Screen Shot 2022-11-18 at 1 07 52 AM" src="https://user-images.githubusercontent.com/139536/202442139-7b1bef4f-fd94-4e99-9b65-017ded8eb26f.png">

Now I can trigger it by publishing "Turn on Do Not Disturb" to a MQTT topic: `mac2mqtt/My-MacBook-Pro/command/runshortcut`.