### PR TITLE
Return empty string if no battery is present on the Mac

### DIFF
--- a/mac2mqtt.go
+++ b/mac2mqtt.go
@@ -281,9 +281,13 @@ func getBatteryChargePercent() string {
 	//  -InternalBattery-0 (id=4653155)        100%; discharging; 20:00 remaining present: true
 
 	r := regexp.MustCompile(`(\d+)%`)
-	percent := r.FindStringSubmatch(output)[1]
+	res := r.FindStringSubmatch(output)
 
-	return percent
+	if len(res) == 0 {
+		return ""
+	}
+
+	return res[1]
 }
 
 func updateBattery(client mqtt.Client) {


### PR DESCRIPTION
Return empty string if no battery is present on the Mac (as is the case on the Mac Pro)

Resulting topics on MQTT

<img width="297" alt="Screenshot 2023-01-10 at 20 11 30" src="https://user-images.githubusercontent.com/2021654/211652099-42a4ee90-6640-46ef-9ae3-499a7ca295fa.png">
